### PR TITLE
Coleta métrica de deploy contínuo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,3 +24,5 @@ deploy:
      skip_cleanup: true
      on:
        branch: development 
+after_deploy:
+    - curl -X POST $PINGOUT_URL/$PINGOUT_UUID/ping


### PR DESCRIPTION
## Tipo da mudança 
- [ ] Resolve Bug 
- [X] Adiciona nova funcionalidade 
- [ ] Atualiza documentação 

## Descrição das mudanças 
Dá ping depois de cada deploy no app pingout, para coletar quantidade de deploys contínuos que ocorreram em determinado período de tempo

## Conecte a Issue 
Conecte sua issue abaixo com o GitHub :v:
